### PR TITLE
Fix Ngarrgu Tindebeek profile resource step names

### DIFF
--- a/profiles/ngarrgu-tindebeek/config.yaml
+++ b/profiles/ngarrgu-tindebeek/config.yaml
@@ -26,14 +26,23 @@ group-components:
 set-resources:
     download:
         cpus_per_task: 1
-        mem_mb: 2500
+        mem_mb: 2560
         slurm_partition: trevor
     stage1:
         cpus_per_task: 1
-        mem_mb: 16000
-    imaging:
+        mem_mb: 8000
+        runtime: 120
+    contam:
+        cpus_per_task: 64
+        mem_mb: 1000000
+        runtime: 7200
+    preprocess:
         cpus_per_task: 12
-        mem_mb: 30000
+        mem_mb: 26000
         slurm_partition: trevor
-    
+    mosaic:
+        cpus_per_task: 12
+        mem_mb: 26000
+        slurm_partition: trevor
+
 # Note, ensure that the sum of runtimes across preprocess + mosaic does not exceed the limit, since these are grouped together.


### PR DESCRIPTION
## Summary
- set explicit resource requests for contam to 1,000,000 MB

## Testing
- ❌ `pixi install --no-lockfile-update` *(command not found: pixi)*
- ❌ `pixi env list` *(command not found: pixi)*
- ❌ `pixi run -e jwst python -c "import jwst, sys; print(jwst.__version__)"` *(command not found: pixi)*
- ❌ `pixi run -e snakemake snakemake -n -s workflow/SingleField_leo-00.smk` *(command not found: pixi)*

------
https://chatgpt.com/codex/tasks/task_e_68a5604844788329b4a69fe31ef3af4d